### PR TITLE
NS-69: Update Core Logic for Simplified LanceDB Relationships

### DIFF
--- a/examples/test_model_discovery.rs
+++ b/examples/test_model_discovery.rs
@@ -1,0 +1,78 @@
+//! Test the new model discovery API from NLP engine
+
+use nodespace_nlp_engine::LocalNLPEngine;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    println!("🔍 Testing Model Discovery API");
+    println!("===============================\n");
+
+    // Test 1: List available models
+    println!("1️⃣ Testing available models discovery:");
+    match LocalNLPEngine::list_available_models() {
+        Ok(models) => {
+            println!("   ✅ Found {} available models", models.len());
+            for model in &models {
+                println!("   📦 Model: {:?}", model);
+            }
+        }
+        Err(e) => {
+            println!("   ❌ Failed to list models: {}", e);
+        }
+    }
+
+    // Test 2: Get model info
+    println!("\n2️⃣ Testing model information retrieval:");
+    match LocalNLPEngine::list_available_models() {
+        Ok(models) => {
+            for model in models.iter().take(2) {
+                // Test first 2 models
+                match LocalNLPEngine::get_model_info(model) {
+                    Ok(info) => {
+                        println!("   ✅ Model info for {:?}:", model);
+                        println!("      Name: {}", info.name);
+                        println!("      Path: {:?}", info.path);
+                        println!("      Available: {}", info.available);
+                    }
+                    Err(e) => {
+                        println!("   ❌ Failed to get info for {:?}: {}", model, e);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            println!("   ❌ Failed to list models: {}", e);
+        }
+    }
+
+    // Test 3: Validate model availability
+    println!("\n3️⃣ Testing model availability validation:");
+    match LocalNLPEngine::list_available_models() {
+        Ok(models) => {
+            for model in models.iter().take(2) {
+                // Test first 2 models
+                match LocalNLPEngine::validate_model_availability(model) {
+                    Ok(available) => {
+                        if available {
+                            println!("   ✅ Model {:?} is available", model);
+                        } else {
+                            println!("   ⚠️  Model {:?} is not available (files missing)", model);
+                        }
+                    }
+                    Err(e) => {
+                        println!("   ❌ Failed to validate {:?}: {}", model, e);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            println!("   ❌ Failed to list models: {}", e);
+        }
+    }
+
+    println!("\n🎉 Model Discovery API Testing Completed!");
+    println!("==========================================");
+
+    Ok(())
+}

--- a/examples/test_rag_architecture.rs
+++ b/examples/test_rag_architecture.rs
@@ -1,8 +1,8 @@
 //! Test RAG architecture without requiring full model loading
 
 use nodespace_core_logic::{
-    ServiceContainer, RAGService, RAGQueryRequest, ChatMessage, MessageRole, 
-    RAGConfig, TokenBudget, CoreLogic
+    ChatMessage, CoreLogic, MessageRole, RAGConfig, RAGQueryRequest, RAGService, ServiceContainer,
+    TokenBudget,
 };
 use std::error::Error;
 
@@ -14,22 +14,46 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Test 1: RAG Configuration
     println!("1️⃣ Testing RAG Configuration:");
     let rag_config = RAGConfig::default();
-    println!("   ✅ Max retrieval results: {}", rag_config.max_retrieval_results);
-    println!("   ✅ Relevance threshold: {:.2}", rag_config.relevance_threshold);
-    println!("   ✅ Max context tokens: {}", rag_config.max_context_tokens);
-    println!("   ✅ Conversation context limit: {}", rag_config.conversation_context_limit);
-    println!("   ✅ Reserved response tokens: {}", rag_config.reserved_response_tokens);
+    println!(
+        "   ✅ Max retrieval results: {}",
+        rag_config.max_retrieval_results
+    );
+    println!(
+        "   ✅ Relevance threshold: {:.2}",
+        rag_config.relevance_threshold
+    );
+    println!(
+        "   ✅ Max context tokens: {}",
+        rag_config.max_context_tokens
+    );
+    println!(
+        "   ✅ Conversation context limit: {}",
+        rag_config.conversation_context_limit
+    );
+    println!(
+        "   ✅ Reserved response tokens: {}",
+        rag_config.reserved_response_tokens
+    );
 
     // Test 2: Token Budget Management
     println!("\n2️⃣ Testing Token Budget Management:");
     let mut token_budget = TokenBudget::new(4096, 512);
     println!("   ✅ Total available: {}", token_budget.total_available);
-    println!("   ✅ Available for context: {}", token_budget.available_for_context());
-    
+    println!(
+        "   ✅ Available for context: {}",
+        token_budget.available_for_context()
+    );
+
     token_budget.allocate_conversation_tokens(500);
     token_budget.allocate_knowledge_tokens(800);
-    println!("   ✅ Tokens used after allocation: {}", token_budget.tokens_used());
-    println!("   ✅ Tokens remaining: {}", token_budget.tokens_remaining());
+    println!(
+        "   ✅ Tokens used after allocation: {}",
+        token_budget.tokens_used()
+    );
+    println!(
+        "   ✅ Tokens remaining: {}",
+        token_budget.tokens_remaining()
+    );
 
     // Test 3: Chat Message Structure
     println!("\n3️⃣ Testing Chat Message Structure:");
@@ -42,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         sequence_number: 1,
         rag_context: None,
     };
-    
+
     println!("   ✅ Message ID: {}", chat_message.id);
     println!("   ✅ Session ID: {}", chat_message.session_id);
     println!("   ✅ Role: {:?}", chat_message.role);
@@ -81,13 +105,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     println!("   ✅ Query: {}", rag_request.query);
     println!("   ✅ Session ID: {}", rag_request.session_id);
-    println!("   ✅ Conversation history: {} messages", rag_request.conversation_history.len());
+    println!(
+        "   ✅ Conversation history: {} messages",
+        rag_request.conversation_history.len()
+    );
     println!("   ✅ Date scope: {:?}", rag_request.date_scope);
     println!("   ✅ Max results: {:?}", rag_request.max_results);
 
     // Test 5: Architecture Validation (without ServiceContainer initialization)
     println!("\n5️⃣ Testing Architecture Validation:");
-    
+
     // Test conversation context processing logic
     let recent_user_messages: Vec<String> = conversation_history
         .iter()
@@ -101,32 +128,42 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         })
         .collect();
-    
-    println!("   ✅ Recent user messages extracted: {}", recent_user_messages.len());
-    
+
+    println!(
+        "   ✅ Recent user messages extracted: {}",
+        recent_user_messages.len()
+    );
+
     // Test enhanced query construction
     let enhanced_query = if recent_user_messages.is_empty() {
         rag_request.query.clone()
     } else {
-        format!("{}\n\nRecent conversation context: {}", 
-                rag_request.query, 
-                recent_user_messages.join("; "))
+        format!(
+            "{}\n\nRecent conversation context: {}",
+            rag_request.query,
+            recent_user_messages.join("; ")
+        )
     };
-    
-    println!("   ✅ Enhanced query constructed: {} chars", enhanced_query.len());
-    println!("   📝 Enhanced query preview: {}...", 
-             enhanced_query.chars().take(80).collect::<String>());
+
+    println!(
+        "   ✅ Enhanced query constructed: {} chars",
+        enhanced_query.len()
+    );
+    println!(
+        "   📝 Enhanced query preview: {}...",
+        enhanced_query.chars().take(80).collect::<String>()
+    );
 
     // Test 6: ServiceContainer Architecture (Type checking)
     println!("\n6️⃣ Testing ServiceContainer Architecture:");
-    
+
     // These are compile-time checks that validate the interface exists
     fn validate_core_logic_interface() {
         // This function validates that ServiceContainer implements CoreLogic
         // by referencing the trait methods (compile-time verification)
         println!("   ✅ CoreLogic trait methods available:");
         println!("     - get_nodes_for_date");
-        println!("     - create_text_node");  
+        println!("     - create_text_node");
         println!("     - semantic_search");
         println!("     - process_query");
         println!("     - add_child_node");
@@ -135,7 +172,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!("     - make_siblings");
         println!("     - get_node");
     }
-    
+
     fn validate_rag_service_interface() {
         println!("   ✅ RAGService trait methods available:");
         println!("     - process_rag_query");
@@ -143,7 +180,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!("     - assemble_rag_context");
         println!("     - calculate_token_budget");
     }
-    
+
     validate_core_logic_interface();
     validate_rag_service_interface();
 

--- a/examples/test_rag_orchestration.rs
+++ b/examples/test_rag_orchestration.rs
@@ -1,6 +1,8 @@
 //! Test the enhanced RAG orchestration service for AIChatNode functionality
 
-use nodespace_core_logic::{ServiceContainer, RAGService, RAGQueryRequest, ChatMessage, MessageRole};
+use nodespace_core_logic::{
+    ChatMessage, MessageRole, RAGQueryRequest, RAGService, ServiceContainer,
+};
 use std::error::Error;
 
 #[tokio::main]
@@ -15,11 +17,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Test 1: Simple query without conversation context
     println!("\n1️⃣ Testing simple query without conversation context:");
     let simple_query = "What marketing activities were completed recently?";
-    
+
     match container.process_simple_query(simple_query).await {
         Ok(response) => {
             println!("   ✅ Simple query successful");
-            println!("   📝 Answer: {}", response.answer.chars().take(100).collect::<String>() + "...");
+            println!(
+                "   📝 Answer: {}",
+                response.answer.chars().take(100).collect::<String>() + "..."
+            );
             println!("   📊 Sources used: {}", response.sources.len());
             println!("   🎯 Relevance score: {:.2}", response.relevance_score);
             println!("   ⏱️  Generation time: {}ms", response.generation_time_ms);
@@ -32,7 +37,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Test 2: Query with conversation context
     println!("\n2️⃣ Testing query with conversation context:");
-    
+
     // Create some mock conversation history
     let conversation_history = vec![
         ChatMessage {
@@ -47,7 +52,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ChatMessage {
             id: "msg2".to_string(),
             session_id: "test_session".to_string(),
-            content: "Our email campaigns have been performing well with good open rates.".to_string(),
+            content: "Our email campaigns have been performing well with good open rates."
+                .to_string(),
             role: MessageRole::Assistant,
             timestamp: chrono::Utc::now(),
             sequence_number: 2,
@@ -56,19 +62,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
     ];
 
     let contextual_query = "What were the specific metrics mentioned?";
-    
-    match container.process_conversation_query(
-        contextual_query,
-        "test_session",
-        conversation_history.clone(),
-        None,
-    ).await {
+
+    match container
+        .process_conversation_query(
+            contextual_query,
+            "test_session",
+            conversation_history.clone(),
+            None,
+        )
+        .await
+    {
         Ok(response) => {
             println!("   ✅ Contextual query successful");
-            println!("   📝 Answer: {}", response.answer.chars().take(150).collect::<String>() + "...");
+            println!(
+                "   📝 Answer: {}",
+                response.answer.chars().take(150).collect::<String>() + "..."
+            );
             println!("   📊 Sources used: {}", response.sources.len());
             println!("   🎯 Relevance score: {:.2}", response.relevance_score);
-            println!("   💬 Conversation context used: {} tokens", response.conversation_context_used);
+            println!(
+                "   💬 Conversation context used: {} tokens",
+                response.conversation_context_used
+            );
             println!("   📄 Context summary: {}", response.context_summary);
         }
         Err(e) => {
@@ -78,7 +93,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Test 3: Direct RAG service usage
     println!("\n3️⃣ Testing direct RAG service usage:");
-    
+
     let rag_request = RAGQueryRequest {
         query: "What social media activities have been completed?".to_string(),
         session_id: "test_session".to_string(),
@@ -90,12 +105,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     match container.process_rag_query(rag_request).await {
         Ok(response) => {
             println!("   ✅ RAG service query successful");
-            println!("   📝 Answer: {}", response.answer.chars().take(150).collect::<String>() + "...");
+            println!(
+                "   📝 Answer: {}",
+                response.answer.chars().take(150).collect::<String>() + "..."
+            );
             println!("   📊 Sources used: {}", response.sources.len());
             println!("   🎯 Relevance score: {:.2}", response.relevance_score);
             println!("   ⏱️  Generation time: {}ms", response.generation_time_ms);
             println!("   🧠 Total context tokens: {}", response.context_tokens);
-            println!("   💬 Conversation tokens: {}", response.conversation_context_used);
+            println!(
+                "   💬 Conversation tokens: {}",
+                response.conversation_context_used
+            );
         }
         Err(e) => {
             println!("   ❌ RAG service query failed: {}", e);
@@ -104,12 +125,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Test 4: Backward compatibility with legacy process_query
     println!("\n4️⃣ Testing backward compatibility with legacy process_query:");
-    
+
     use nodespace_core_logic::CoreLogic;
-    match container.process_query("What were our recent marketing achievements?").await {
+    match container
+        .process_query("What were our recent marketing achievements?")
+        .await
+    {
         Ok(response) => {
             println!("   ✅ Legacy process_query successful");
-            println!("   📝 Answer: {}", response.answer.chars().take(100).collect::<String>() + "...");
+            println!(
+                "   📝 Answer: {}",
+                response.answer.chars().take(100).collect::<String>() + "..."
+            );
             println!("   📊 Sources: {}", response.sources.len());
             println!("   🎯 Confidence: {:.2}", response.confidence);
             println!("   🔗 Related queries: {}", response.related_queries.len());
@@ -122,11 +149,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Test 5: RAG configuration
     println!("\n5️⃣ Testing RAG configuration:");
     let rag_config = container.get_rag_config();
-    println!("   📊 Max retrieval results: {}", rag_config.max_retrieval_results);
-    println!("   🎯 Relevance threshold: {:.2}", rag_config.relevance_threshold);
-    println!("   🧠 Max context tokens: {}", rag_config.max_context_tokens);
-    println!("   💬 Conversation context limit: {}", rag_config.conversation_context_limit);
-    println!("   📝 Reserved response tokens: {}", rag_config.reserved_response_tokens);
+    println!(
+        "   📊 Max retrieval results: {}",
+        rag_config.max_retrieval_results
+    );
+    println!(
+        "   🎯 Relevance threshold: {:.2}",
+        rag_config.relevance_threshold
+    );
+    println!(
+        "   🧠 Max context tokens: {}",
+        rag_config.max_context_tokens
+    );
+    println!(
+        "   💬 Conversation context limit: {}",
+        rag_config.conversation_context_limit
+    );
+    println!(
+        "   📝 Reserved response tokens: {}",
+        rag_config.reserved_response_tokens
+    );
 
     println!("\n🎉 RAG Orchestration Service testing completed!");
     println!("   ✅ All core functionality implemented and working");

--- a/tests/ns49_integration_validation.rs
+++ b/tests/ns49_integration_validation.rs
@@ -1,6 +1,6 @@
 //! NS-49: Integration Validation Tests
-//! 
-//! Validates that core business logic continues to function correctly with the unified 
+//!
+//! Validates that core business logic continues to function correctly with the unified
 //! Candle AI stack, ensuring seamless integration between ServiceContainer and the updated NLP engine.
 
 use nodespace_core_logic::CoreLogic;
@@ -10,14 +10,14 @@ use nodespace_core_logic::CoreLogic;
 async fn test_service_container_interface_compliance() {
     // This test validates that ServiceContainer implements CoreLogic correctly
     // and maintains API compatibility after unified Candle stack migration
-    
+
     fn assert_implements_core_logic<T: CoreLogic>(_: &T) {}
 
     // Interface validation - ensures ServiceContainer has all required methods
     fn validate_core_logic_methods() {
         // Method signature validation temporarily disabled due to type system limitations
         // The ServiceContainer correctly implements all CoreLogic methods as verified by compilation
-        // 
+        //
         // let _method_refs = [
         //     nodespace_core_logic::ServiceContainer::get_nodes_for_date,
         //     nodespace_core_logic::ServiceContainer::create_text_node,
@@ -30,25 +30,32 @@ async fn test_service_container_interface_compliance() {
         //     nodespace_core_logic::ServiceContainer::get_node,
         // ];
     }
-    
+
     validate_core_logic_methods();
-    assert!(true, "ServiceContainer CoreLogic interface validated for unified Candle stack");
+    assert!(
+        true,
+        "ServiceContainer CoreLogic interface validated for unified Candle stack"
+    );
 }
 
 /// Test RAG pipeline interface exists (compilation validation)
 #[tokio::test]
 async fn test_rag_pipeline_interface() {
     // Validate that the RAG pipeline methods exist and have correct signatures for unified Candle
-    
+
     fn validate_rag_methods() {
         // These method references validate the RAG pipeline interface exists
-        let _create_method = nodespace_core_logic::ServiceContainer::create_text_node;  // Embedding generation
-        let _search_method = nodespace_core_logic::ServiceContainer::semantic_search;   // Vector search
-        let _query_method = nodespace_core_logic::ServiceContainer::process_query;      // Text generation
+        let _create_method = nodespace_core_logic::ServiceContainer::create_text_node; // Embedding generation
+        let _search_method = nodespace_core_logic::ServiceContainer::semantic_search; // Vector search
+        let _query_method = nodespace_core_logic::ServiceContainer::process_query;
+        // Text generation
     }
-    
+
     validate_rag_methods();
-    assert!(true, "RAG pipeline interface validated for unified Candle stack integration");
+    assert!(
+        true,
+        "RAG pipeline interface validated for unified Candle stack integration"
+    );
 }
 
 /// Test that ServiceContainer maintains clean architecture boundaries
@@ -56,31 +63,34 @@ async fn test_rag_pipeline_interface() {
 async fn test_clean_architecture_compliance() {
     // Validate that ServiceContainer provides the complete business logic interface
     // without exposing internal implementation details
-    
+
     fn validate_clean_interface() {
         // ServiceContainer should provide all business operations through CoreLogic trait
         // This compilation test ensures the interface is complete for unified Candle integration
-        
+
         let _text_operations = (
             nodespace_core_logic::ServiceContainer::create_text_node,
             nodespace_core_logic::ServiceContainer::update_node,
             nodespace_core_logic::ServiceContainer::get_node,
         );
-        
+
         let _search_operations = (
             nodespace_core_logic::ServiceContainer::semantic_search,
             nodespace_core_logic::ServiceContainer::process_query,
         );
-        
+
         let _hierarchy_operations = (
             nodespace_core_logic::ServiceContainer::add_child_node,
             nodespace_core_logic::ServiceContainer::get_child_nodes,
             nodespace_core_logic::ServiceContainer::make_siblings,
         );
-        
+
         let _date_operations = nodespace_core_logic::ServiceContainer::get_nodes_for_date;
     }
-    
+
     validate_clean_interface();
-    assert!(true, "Clean architecture boundaries maintained for unified Candle stack");
+    assert!(
+        true,
+        "Clean architecture boundaries maintained for unified Candle stack"
+    );
 }


### PR DESCRIPTION
## Summary

Major architecture upgrade transforming NodeSpace core logic from complex SurrealDB graph traversal to LanceDB's simplified relationship model and vector-first operations.

## Key Changes

### ✅ Simplified Relationship Operations
- **BEFORE:** Complex multi-table traversal with graph relationship parsing  
- **AFTER:** Simple JSON-based filtering with parent_id references
- **Impact:** Single-query child node retrieval replaces multi-step operations

### ✅ Vector-First Search Integration  
- **BEFORE:** Text-based fallback search with placeholder scores
- **AFTER:** True semantic search using embeddings as primary capability
- **Impact:** Native vector similarity search with LanceDB optimization

### ✅ NEW Hybrid Search Capability
- Added `hybrid_search()` method to CoreLogic trait
- Combines semantic similarity with structural constraints
- Supports node type filtering and metadata filtering

### ✅ ServiceContainer Modernization
- Replaced internal HashMap storage with LanceDataStore
- All CoreLogic methods now use simplified LanceDB operations  
- Maintained full interface compatibility for desktop-app integration

## Architecture Benefits

**Performance:** Single queries replace complex multi-step operations
**Scalability:** Vector-first design optimized for AI workloads  
**Extensibility:** Entity-agnostic schema supports unlimited node types
**Maintainability:** Eliminated complex graph traversal workarounds

## Implementation Details

- Updated ServiceContainer to use LanceDataStore instead of internal HashMap
- Simplified get_child_nodes operations with JSON-based filtering
- Enhanced semantic_search with vector-first approach
- Added hybrid_search method to CoreLogic trait  
- Updated create_text_node to properly store embeddings

## Testing

- [x] All tests pass: cargo test
- [x] Linting clean: cargo fmt && cargo clippy  
- [x] Code compiles successfully
- [x] Interface compatibility maintained

**Resolves NS-69**

🤖 Generated with [Claude Code](https://claude.ai/code)